### PR TITLE
Making some changes to improve the usability of the ellipse detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+ellipse_det
+.vscode/ipch/458a52dbac376d2e/Main.ipch
+.vscode/ipch/458a52dbac376d2e/mmap_address.bin

--- a/EllipseDetectorYaed.h
+++ b/EllipseDetectorYaed.h
@@ -27,7 +27,7 @@ This class implements a very fast ellipse detector, codename: YAED (Yet Another 
 
 #pragma once
 
-#include <cxcore.hpp>
+// #include <cxcore.hpp>
 #include <cv.h>
 #include <highgui.h>
 #include <stdio.h>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fast_ellipse_detector
 This is the implementation in C++ of the paper: 'A fast and effective ellipse detector for embedded vision applications'.
-It runs on Ubuntu 16.04.  
+It runs on Ubuntu 16.04 with OpenCV 2.4.13.  
 
 Original author: mikispace (https://sourceforge.net/projects/yaed/)
 

--- a/setup/install-opencv-2.4.13.sh
+++ b/setup/install-opencv-2.4.13.sh
@@ -1,0 +1,30 @@
+# install dependencies
+sudo apt-get update
+sudo apt-get install -y build-essential
+sudo apt-get install -y cmake
+sudo apt-get install -y libgtk2.0-dev
+sudo apt-get install -y pkg-config
+sudo apt-get install -y python-numpy python-dev
+sudo apt-get install -y libavcodec-dev libavformat-dev libswscale-dev
+sudo apt-get install -y libjpeg-dev libpng12-dev libtiff5-dev libjasper-dev
+ 
+sudo apt-get -qq install libopencv-dev build-essential checkinstall cmake pkg-config yasm libjpeg-dev libjasper-dev libavcodec-dev libavformat-dev libswscale-dev libdc1394-22-dev libxine2 libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libv4l-dev python-dev python-numpy libtbb-dev libqt4-dev libgtk2.0-dev libmp3lame-dev libopencore-amrnb-dev libopencore-amrwb-dev libtheora-dev libvorbis-dev libxvidcore-dev x264 v4l-utils
+ 
+# download opencv-2.4.13
+wget http://downloads.sourceforge.net/project/opencvlibrary/opencv-unix/2.4.13/opencv-2.4.13.zip
+unzip opencv-2.4.13.zip
+cd opencv-2.4.13
+mkdir release
+cd release
+ 
+# compile and install
+cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=/usr/bin/g++ CMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_TBB=ON -DBUILD_NEW_PYTHON_SUPPORT=ON -DWITH_V4L=ON -DINSTALL_C_EXAMPLES=ON -DINSTALL_PYTHON_EXAMPLES=ON -DBUILD_EXAMPLES=ON -DWITH_QT=ON -DWITH_OPENGL=ON -DBUILD_FAT_JAVA_LIB=ON -DINSTALL_TO_MANGLED_PATHS=ON -DINSTALL_CREATE_DISTRIB=ON -DINSTALL_TESTS=ON -DENABLE_FAST_MATH=ON -DWITH_IMAGEIO=ON -DBUILD_SHARED_LIBS=OFF -DWITH_GSTREAMER=ON ..
+make all -j2 # 2 cores
+sudo make install
+ 
+# ignore libdc1394 error http://stackoverflow.com/questions/12689304/ctypes-error-libdc1394-error-failed-to-initialize-libdc1394
+ 
+#python
+#> import cv2
+#> cv2.SIFT
+#<built-in function SIFT>


### PR DESCRIPTION
I've added an install script (not my own) to install OpenCV 2.4.13 on Ubuntu 16.04 and updated the README to reflect that OpenCV 2.4.13 is confirmed to work with the ellipse detector program. I've also updated the Main.cpp file to allow for the passing of an image path to the ellipse detector program and to allow the resulting image window to resize if the image is larger than the screen resolution.